### PR TITLE
Implement log catcher directly into multilogger 

### DIFF
--- a/color/attribute.go
+++ b/color/attribute.go
@@ -4,22 +4,20 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+
+	"github.com/coveooss/multilogger/errors"
 )
 
 // Attributes convert any object representation to valid color attributes.
 // It will panic if an invalid attribute is provided.
 func Attributes(attributes ...interface{}) []Attribute {
-	result, err := TryConvertAttributes(attributes...)
-	if err != nil {
-		panic(err)
-	}
-	return result
+	return errors.Must(TryConvertAttributes(attributes...)).([]Attribute)
 }
 
 // TryConvertAttributes tries to convert any object representation to valid color attribute.
 // It returns an error if some parameters cannot be converted to valid attributes.
 func TryConvertAttributes(attributes ...interface{}) ([]Attribute, error) {
-	var errors []string
+	var errors errors.Array
 	result := make([]Attribute, 0, len(attributes))
 
 	idFunc := func(c rune) bool { return !unicode.IsLetter(c) && !unicode.IsNumber(c) }
@@ -39,12 +37,9 @@ func TryConvertAttributes(attributes ...interface{}) ([]Attribute, error) {
 			if attr, match := colorNames[strings.ToLower(attribute)]; match {
 				result = append(result, attr)
 			} else {
-				errors = append(errors, fmt.Sprintf("Attribute not found %s", attribute))
+				errors = append(errors, fmt.Errorf("Attribute not found %s", attribute))
 			}
 		}
 	}
-	if len(errors) > 0 {
-		return result, fmt.Errorf(strings.Join(errors, "\n"))
-	}
-	return result, nil
+	return result, errors.AsError()
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,107 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+// Raise issues a panic with a formated message representing a managed error
+func Raise(format string, args ...interface{}) {
+	panic(Managed(fmt.Sprintf(format, args...)))
+}
+
+// Printf print a message to the stderr in red
+func Printf(format string, args ...interface{}) {
+	Print(fmt.Errorf(format, args...))
+}
+
+// Print print error to the stderr in red
+func Print(err error) {
+	fmt.Fprintln(color.Error, color.RedString(fmt.Sprintf("%v", err)))
+}
+
+// Must traps errors and return the remaining results to the caller
+// If there is an error, a panic is issued
+func Must(result ...interface{}) interface{} {
+	if len(result) == 0 {
+		return nil
+	}
+	last := len(result) - 1
+	err := result[last]
+	if err != nil {
+		panic(err)
+	}
+
+	result = result[:last]
+	switch len(result) {
+	case 0:
+		return nil
+	case 1:
+		return result[0]
+	default:
+		return result
+	}
+}
+
+// Trap catch any panic exception, and convert it to error
+// It must be called with current error state and recover() as argument
+func Trap(sourceErr error, recovered interface{}) (err error) {
+	err = sourceErr
+	var trap error
+	switch rec := recovered.(type) {
+	case nil:
+	case error:
+		trap = rec
+	default:
+		trap = fmt.Errorf("%v", rec)
+	}
+	if trap != nil {
+		if err != nil {
+			return Array{err, trap}
+		}
+		return trap
+	}
+	return
+}
+
+// TemplateNotFoundError is returned when a template does not exist
+type TemplateNotFoundError struct {
+	name string
+}
+
+func (e TemplateNotFoundError) Error() string {
+	return fmt.Sprintf("Template %s not found", e.name)
+}
+
+// Array represent an array of error
+type Array []error
+
+func (errors Array) Error() string {
+	errorsStr := make([]string, 0, len(errors))
+	for i := range errors {
+		if errors[i] != nil {
+			errorsStr = append(errorsStr, errors[i].Error())
+		}
+	}
+	return strings.Join(errorsStr, "\n")
+}
+
+// AsError returns nil if there is no error in the array
+func (errors Array) AsError() error {
+	switch len(errors) {
+	case 0:
+		return nil
+	case 1:
+		return errors[0]
+	}
+	return errors
+}
+
+// Managed indicates an error that is properly handled (no need to print out stack)
+type Managed string
+
+func (err Managed) Error() string {
+	return string(err)
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -7,23 +7,23 @@ import (
 	"github.com/fatih/color"
 )
 
-// Raise issues a panic with a formated message representing a managed error
+// Raise issues a panic with a formated message representing a managed error.
 func Raise(format string, args ...interface{}) {
 	panic(Managed(fmt.Sprintf(format, args...)))
 }
 
-// Printf print a message to the stderr in red
+// Printf print a message to the stderr in red.
 func Printf(format string, args ...interface{}) {
 	Print(fmt.Errorf(format, args...))
 }
 
-// Print print error to the stderr in red
+// Print print error to the stderr in red.
 func Print(err error) {
 	fmt.Fprintln(color.Error, color.RedString(fmt.Sprintf("%v", err)))
 }
 
-// Must traps errors and return the remaining results to the caller
-// If there is an error, a panic is issued
+// Must traps errors and returns the remaining results to the caller.
+// If there is an error, a panic is issued.
 func Must(result ...interface{}) interface{} {
 	if len(result) == 0 {
 		return nil
@@ -45,8 +45,8 @@ func Must(result ...interface{}) interface{} {
 	}
 }
 
-// Trap catch any panic exception, and convert it to error
-// It must be called with current error state and recover() as argument
+// Trap catches any panic exception, and converts it to error.
+// It must be called with current error state and recover() as argument.
 func Trap(sourceErr error, recovered interface{}) (err error) {
 	err = sourceErr
 	var trap error
@@ -66,7 +66,7 @@ func Trap(sourceErr error, recovered interface{}) (err error) {
 	return
 }
 
-// TemplateNotFoundError is returned when a template does not exist
+// TemplateNotFoundError is returned when a template does not exist.
 type TemplateNotFoundError struct {
 	name string
 }
@@ -75,7 +75,7 @@ func (e TemplateNotFoundError) Error() string {
 	return fmt.Sprintf("Template %s not found", e.name)
 }
 
-// Array represent an array of error
+// Array represent an array of error.
 type Array []error
 
 func (errors Array) Error() string {
@@ -88,7 +88,7 @@ func (errors Array) Error() string {
 	return strings.Join(errorsStr, "\n")
 }
 
-// AsError returns nil if there is no error in the array
+// AsError returns nil if there is no error in the array.
 func (errors Array) AsError() error {
 	switch len(errors) {
 	case 0:
@@ -99,7 +99,7 @@ func (errors Array) AsError() error {
 	return errors
 }
 
-// Managed indicates an error that is properly handled (no need to print out stack)
+// Managed indicates an error that is properly handled (no need to print out stack).
 type Managed string
 
 func (err Managed) Error() string {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,0 +1,71 @@
+package errors
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMust(t *testing.T) {
+	type i = interface{}
+	tests := []struct {
+		name    string
+		result  []i
+		want    i
+		wantErr bool
+	}{
+		{"Nil", nil, nil, false},
+		{"1 arg", []i{"Hello"}, nil, true},
+		{"1 arg, nil", []i{nil}, nil, false},
+		{"2 arg, second not nul", []i{"Hello", "World"}, nil, true},
+		{"2 arg, second nul", []i{"Hello", nil}, "Hello", false},
+		{"3 arg, last nul", []i{"Hello", "World", nil}, []i{"Hello", "World"}, false},
+	}
+	for _, tt := range tests {
+		var err error
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() { err = Trap(err, recover()) }()
+			if got := Must(tt.result...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Must() = %v, want %v", got, tt.want)
+			}
+		})
+		if (err != nil) != tt.wantErr {
+			t.Errorf("CreateList() error = %v, wantErr %v", err, tt.wantErr)
+		}
+	}
+}
+
+func TestPrint(t *testing.T) {
+	Printf("This is an error")
+	var err error
+	func() {
+		defer func() { err = Trap(err, recover()) }()
+		Raise("This is also an error")
+	}()
+	assert.NotNil(t, err, "Error should be not nil")
+	Print(err)
+
+	err = nil
+	func() {
+		defer func() { err = Trap(err, recover()) }()
+		panic(911)
+	}()
+	assert.NotNil(t, err, "Error should be not nil")
+	Print(err)
+
+	// We left the err intact to test array creation
+	func() {
+		defer func() { err = Trap(err, recover()) }()
+		panic(TemplateNotFoundError{"filename"})
+	}()
+	assert.NotNil(t, err, "Error should be not nil")
+	Print(err)
+
+	err = nil
+	func() {
+		defer func() { err = Trap(err, recover()) }()
+		// No error
+	}()
+	assert.Nil(t, err, "Error should be nil")
+}

--- a/file_hook.go
+++ b/file_hook.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -17,39 +16,40 @@ type fileHook struct {
 }
 
 func (hook *fileHook) Fire(entry *logrus.Entry) (err error) {
-	var output []byte
-	if entry.Level == outputLevel {
-		output = []byte(entry.Message)
-	} else {
-		if output, err = hook.formatEntry(entry); err != nil {
-			return err
-		}
-	}
-
-	fileMutex.Lock()
-	defer fileMutex.Unlock()
-	if hook.file == nil {
-		logFileExists := false
-		if _, err := os.Stat(hook.filename); err == nil {
-			logFileExists = true
-		}
-		if hook.file, err = os.OpenFile(hook.filename, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0666); err != nil {
-			return fmt.Errorf("Unable to open log file %s: %w", hook.filename, err)
-		}
-		if hook.addHeader {
-			if logFileExists {
-				// Add a bit of whitespace before logging
-				hook.file.Write([]byte("\n"))
+	return hook.fire(entry, func() error {
+		name := fmt.Sprintf("FileHook %s", hook.filename)
+		output := entry.Message
+		if entry.Level != outputLevel {
+			if output, err = hook.formatEntry(name, entry); err != nil {
+				return err
 			}
-			hook.file.Write([]byte(fmt.Sprintf("# Opening log file: %v\n", time.Now().Format("2006/01/02 15:04:05"))))
 		}
-	}
 
-	if _, err = hook.file.Write(output); err != nil {
-		return fmt.Errorf("Unable to print logs to file: %w", err)
-	}
+		fileMutex.Lock()
+		defer fileMutex.Unlock()
+		if hook.file == nil {
+			logFileExists := false
+			if _, err := os.Stat(hook.filename); err == nil {
+				logFileExists = true
+			}
+			if hook.file, err = os.OpenFile(hook.filename, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0666); err != nil {
+				return fmt.Errorf("%s: %w", name, err)
+			}
+			if hook.addHeader {
+				if logFileExists {
+					// Add a bit of whitespace before logging
+					if err := hook.printf(name, hook.file, "\n"); err != nil {
+						return err
+					}
+				}
+				if err := hook.printf(name, hook.file, "# %v\n", entry.Time.Format(defaultTimestampFormat)); err != nil {
+					return err
+				}
+			}
+		}
 
-	return nil
+		return hook.printf(name, hook.file, string(output))
+	})
 }
 
 var fileMutex sync.Mutex

--- a/generic_hook.go
+++ b/generic_hook.go
@@ -2,10 +2,16 @@ package multilogger
 
 import (
 	"fmt"
+	"io"
 	"os"
 
+	"github.com/coveooss/multilogger/errors"
 	"github.com/sirupsen/logrus"
 )
+
+type setLoggerI interface {
+	SetLogger(*Logger)
+}
 
 type genericHookI interface {
 	SetFormatter(logrus.Formatter)
@@ -14,20 +20,45 @@ type genericHookI interface {
 
 type genericHook struct {
 	formatter logrus.Formatter
+	logger    *Logger
 }
 
-func (hook *genericHook) formatEntry(entry *logrus.Entry) ([]byte, error) {
+func (hook *genericHook) formatEntry(name string, entry *logrus.Entry) (string, error) {
 	if hook.formatter == nil {
 		hook.formatter = NewFormatter(true, os.Getenv(FormatFileEnvVar), os.Getenv(FormatEnvVar), DefaultFileFormat)
 	}
 	formatted, err := hook.formatter.Format(entry)
 	if err != nil {
-		return []byte{}, fmt.Errorf("Unable to format the given log entry: %w", err)
+		return "", fmt.Errorf("%s: %w", name, err)
 	}
-	return formatted, nil
+	return string(formatted), nil
+}
+
+func (hook *genericHook) printf(source string, out io.Writer, format string, args ...interface{}) error {
+	text := fmt.Sprintf(format, args...)
+	if n, err := out.Write([]byte(text)); err != nil {
+		return fmt.Errorf("%s: %w", source, err)
+	} else if n != len(text) {
+		return fmt.Errorf("%s: Wrong number of bytes written (%d) for %q", source, n, text)
+	}
+	return nil
+}
+
+func (hook *genericHook) fire(entry *logrus.Entry, f func() error) (err error) {
+	defer func() {
+		err = errors.Trap(err, recover())
+		if hook.logger != nil && err != nil {
+			// We report the error to the logger since the fire mechanism does not
+			// handle errors very well
+			hook.logger.AddError(err)
+		}
+	}()
+
+	return f()
 }
 
 func (hook *genericHook) Levels() []logrus.Level                  { return nil }
 func (hook *genericHook) Fire(entry *logrus.Entry) error          { return fmt.Errorf("Not implemented") }
 func (hook *genericHook) SetFormatter(formatter logrus.Formatter) { hook.formatter = formatter }
 func (hook *genericHook) Formatter() logrus.Formatter             { return hook.formatter }
+func (hook *genericHook) SetLogger(l *Logger)                     { hook.logger = l }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/fatih/color v1.7.0
+	github.com/go-errors/errors v1.0.1
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
+github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/hook.go
+++ b/hook.go
@@ -29,7 +29,7 @@ func NewConsoleHook(name string, level interface{}, format ...interface{}) *Hook
 	return NewHook(name, level, &consoleHook{
 		out:         os.Stdout,
 		log:         logrus.StandardLogger().Out,
-		genericHook: &genericHook{getFormatter(true, format...)},
+		genericHook: &genericHook{formatter: getFormatter(true, format...)},
 	})
 }
 
@@ -41,7 +41,7 @@ func NewFileHook(filename string, level interface{}, format ...interface{}) *Hoo
 		format = append(format, NewFormatter(false, os.Getenv(FormatFileEnvVar), os.Getenv(FormatEnvVar), DefaultFileFormat))
 	}
 	return NewHook(filename, level, &fileHook{
-		genericHook: &genericHook{getFormatter(false, format...)},
+		genericHook: &genericHook{formatter: getFormatter(false, format...)},
 		filename:    filename,
 		addHeader:   true,
 	})

--- a/level.go
+++ b/level.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/coveooss/multilogger/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,11 +34,7 @@ func AcceptedLevelsString() string {
 // ParseLogLevel converts a string or number into a logging level.
 // It panics if the supplied valid cannot be converted into a valid logrus Level.
 func ParseLogLevel(level interface{}) logrus.Level {
-	result, err := TryParseLogLevel(level)
-	if err != nil {
-		panic(err)
-	}
-	return result
+	return errors.Must(TryParseLogLevel(level)).(logrus.Level)
 }
 
 // TryParseLogLevel converts a string or number into a logging level.

--- a/logger.go
+++ b/logger.go
@@ -81,7 +81,7 @@ func (logger *Logger) Copy(module string) *Logger {
 	return &newLogger
 }
 
-// Child returns a new logger with the same module and properties as its parent.
+// Child clones the logger, appending the child's name to the parent's module name.
 func (logger *Logger) Child(child string) *Logger {
 	if module := logger.GetModule(); module != "" {
 		return logger.Copy(fmt.Sprintf("%s:%s", module, child))
@@ -259,13 +259,7 @@ func (logger *Logger) refreshLoggers() *Logger {
 	logger.Logger.Hooks = make(logrus.LevelHooks)
 	var level logrus.Level
 
-	names := make([]string, 0, len(logger.hooks))
-	for key := range logger.hooks {
-		names = append(names, key)
-	}
-	sort.Strings(names)
-
-	for _, key := range names {
+	for _, key := range logger.ListHooks() {
 		hook := logger.hooks[key]
 		logger.Logger.Hooks.Add(hook.hook)
 		if hook.level > level {

--- a/logger.go
+++ b/logger.go
@@ -179,6 +179,16 @@ func (logger *Logger) AddHook(name string, level interface{}, hook logrus.Hook) 
 	return logger.AddHooks(NewHook(name, level, hook))
 }
 
+// TryAddHook adds a hook to the hook collection and associated it with a name and a level.
+// Can also be used to replace an existing hook.
+func (logger *Logger) TryAddHook(name string, level interface{}, hook logrus.Hook) (*Logger, error) {
+	level, err := TryParseLogLevel(level)
+	if err != nil {
+		return nil, err
+	}
+	return logger.AddHook(name, level, hook), nil
+}
+
 // AddHooks adds a collection of hook wrapper as hook to the current logger.
 func (logger *Logger) AddHooks(hooks ...*Hook) *Logger {
 	if logger.hooks == nil {
@@ -229,7 +239,8 @@ func (logger *Logger) GetHookLevel(name string, level interface{}) logrus.Level 
 // SetHookLevel set a new log level for a registered hook.
 func (logger *Logger) SetHookLevel(name string, level interface{}) error {
 	if hook := logger.Hook(name); hook != nil {
-		logger.AddHook(hook.name, level, hook.inner)
+		_, err := logger.TryAddHook(hook.name, level, hook.inner)
+		return err
 	}
 	return fmt.Errorf("Hook not found %s", name)
 }

--- a/logger_catcher_test.go
+++ b/logger_catcher_test.go
@@ -1,0 +1,203 @@
+package multilogger
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os/exec"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogger_Write(t *testing.T) {
+	t.Parallel()
+	type packet struct {
+		sent, expect      string
+		expectSize, delay int
+	}
+	tests := []struct {
+		name       string
+		afterClose string
+		logs       string
+		sequence   []packet
+	}{
+		{"Single", "Hello world\n", "", []packet{
+			{"Hello world\n", "Hello world\n", 12, 0},
+		}},
+		{"Two batch", "Incomplete message\n", "", []packet{
+			{"Incomplete ", "", 11, 0},
+			{"message\n", "Incomplete message\n", 8, 0},
+		}},
+		{"Flush after close", "Not CR terminated", "", []packet{
+			{"Not CR ", "", 7, 0},
+			{"terminated", "", 10, 0},
+		}},
+		{"Test with error in the middle", "That's all",
+			"[Test with error in the middle] 2018/06/24 12:34:56.789 ERROR    This is an error situation\n",
+			[]packet{
+				{"This is an [error] situation\n", "", 29, 0},
+				{"That's all", "", 10, 0},
+			}},
+		{"Test with Error", "",
+			"[Test with Error] 2018/06/24 12:34:56.789 ERROR    This is an error\n",
+			[]packet{
+				{"    [ERROR] This is an error", "", 28, 0},
+			}},
+		{"Test with Warn", "",
+			"[Test with Warn] 2018/06/24 12:34:56.789 WARNING  This is an short warning\n",
+			[]packet{
+				{"    [WARN] This is an short warning", "", 35, 0},
+			}},
+		{"Test with cut warning", "",
+			"[Test with cut warning] 2018/06/24 12:34:56.789 WARNING  This warning message is cut\n",
+			[]packet{
+				{"This [war", "", 9, 0},
+				{"nin", "", 3, 0},
+				{"g] message is cut", "", 17, 0},
+			}},
+		{"Test with info (including warning)", "",
+			"[Test with info (including warning)] 2018/06/24 12:34:56.789 INFO     This is a [Warning] message\n",
+			[]packet{
+				{"[INFO] This is a [Warning] message\n", "", 35, 0},
+			}},
+		{"Test with info and debug (including warning)", "data ...\n",
+			"[Test with info and debug (including warning)] 2018/06/24 12:34:56.789 INFO     This is an important information\n[Test with info and debug (including warning)] 2018/06/24 12:34:56.789 DEBUG    Useless trace\n",
+			[]packet{
+				{"[info] This is an important information", "", 39, 0},
+				{"\ndata ...\n", "data ...\n", 10, 0},
+				{"\t\t[debug]Useless trace", "data ...\n", 22, 0},
+			}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output, logs bytes.Buffer
+			log := getTestLogger(tt.name, "Trace")
+			log.Hook("").SetOut(&logs)
+			log.Hook("").SetStdout(&output)
+
+			for i, p := range tt.sequence {
+				i++
+				n, err := log.Write([]byte(p.sent))
+				assert.NoError(t, err, "LogCatcher.Write() #%d error = %v", i, err)
+				assert.Equal(t, p.expectSize, n, "Unexpected size")
+				assert.Equal(t, p.expect, output.String())
+				if i == len(tt.sequence) {
+					log.Close()
+				}
+			}
+			assert.Equal(t, tt.afterClose, output.String())
+			assert.Equal(t, tt.logs, logs.String())
+			assert.NoError(t, log.GetError())
+		})
+	}
+}
+
+func TestLogCatcher_WriteWithError(t *testing.T) {
+	tests := []struct {
+		name            string
+		text            string
+		err             error
+		wantResultCount int
+		wantErr         string
+	}{
+		{"No error", "", nil, 0, ""},
+		{"Count error", "Write something\n", nil, 0, `ConsoleHook: Wrong number of bytes written (0) for "Write something\n"`},
+		{"Several errors", "First line\n[debug] Hello\nNo output\n", nil, 0, `ConsoleHook: Wrong number of bytes written (0) for "First line\n"`},
+		{"Disk full", "Won't be printed\n", fmt.Errorf("Disk is full"), 0, "ConsoleHook: Disk is full"},
+		{"Disk full 2", "Error will be on close call", fmt.Errorf("Disk is full"), 27, "ConsoleHook: Disk is full"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := getTestLogger(tt.name, "trace")
+			log.Hook("").SetOut(&buggyWriter{tt.err})
+			log.Hook("").SetStdout(&buggyWriter{tt.err})
+
+			gotResultCount, err := log.Write([]byte(tt.text))
+			if err == nil {
+				err = log.Close()
+			}
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantResultCount, gotResultCount)
+		})
+	}
+}
+
+type buggyWriter struct{ err error }
+
+func (bw *buggyWriter) Write(buffer []byte) (int, error) {
+	if bw.err != nil {
+		return 0, bw.err
+	}
+	return 0, nil
+}
+
+func ExampleNew_log_catcher() {
+	log := getTestLogger("catcher", logrus.TraceLevel)
+	cmd := exec.Command("cat")
+	stdin, _ := cmd.StdinPipe()
+	cmd.Stdout, cmd.Stderr = log, log
+	cmd.Start()
+
+	lines := []string{
+		"Hello,",
+		"",
+		"This is a text that contains:",
+		"[Error] Oops! there is an error",
+		"This should be considered as a [warning] message",
+		"This should go directly to output",
+	}
+	for _, line := range lines {
+		io.WriteString(stdin, line+"\n")
+	}
+	stdin.Close()
+	cmd.Wait()
+	// Output:
+	// Hello,
+	//
+	// This is a text that contains:
+	// [catcher] 2018/06/24 12:34:56.789 ERROR    Oops! there is an error
+	// [catcher] 2018/06/24 12:34:56.789 WARNING  This should be considered as a warning message
+	// This should go directly to output
+}
+
+func ExampleNew_log_catcher_disabled() {
+	log := getTestLogger("catcher", logrus.TraceLevel)
+
+	// We disable the log catcher.
+	log.Catcher = false
+	fmt.Fprintln(log, "Hello,")
+	fmt.Fprintln(log)
+	fmt.Fprintln(log, "This is a text that contains:")
+	fmt.Fprintln(log, "[Error] Oops! there is an error")
+	fmt.Fprintln(log, "This should be considered as a [warning] message")
+	fmt.Fprintln(log, "This should go directly to output")
+	// Output:
+	// Hello,
+	//
+	// This is a text that contains:
+	// [Error] Oops! there is an error
+	// This should be considered as a [warning] message
+	// This should go directly to output
+}
+
+func ExampleNew_output_sent_to_info() {
+	log := getTestLogger("catcher", logrus.TraceLevel)
+
+	// We send all regular text to the InfoLevel.
+	log.PrintLevel = logrus.InfoLevel
+	fmt.Fprintln(log, "This is a text that contains:")
+	fmt.Fprintln(log, "[Error] Oops! there is an error")
+	fmt.Fprintln(log, "This should be considered as a [warning] message")
+	fmt.Fprintln(log, "This should go directly to output")
+	// Output:
+	// [catcher] 2018/06/24 12:34:56.789 INFO     This is a text that contains:
+	// [catcher] 2018/06/24 12:34:56.789 ERROR    Oops! there is an error
+	// [catcher] 2018/06/24 12:34:56.789 WARNING  This should be considered as a warning message
+	// [catcher] 2018/06/24 12:34:56.789 INFO     This should go directly to output
+}

--- a/reutils/multimatch.go
+++ b/reutils/multimatch.go
@@ -5,24 +5,24 @@ import (
 	"sync"
 )
 
-// MultiMatch returns a map of matching elements from a list of regular expressions (returning the first matching element)
+// MultiMatch returns a map of matching elements from a list of regular expressions (returning the first matching element).
 func MultiMatch(s string, expressions ...*regexp.Regexp) (map[string]string, int) {
-	for i, re := range expressions {
+	for exprIndex, re := range expressions {
 		if matches := re.FindStringSubmatch(s); len(matches) != 0 {
 			results := make(map[string]string, len(matches))
 			results[""] = matches[0]
-			for i, key := range re.SubexpNames() {
+			for subIndex, key := range re.SubexpNames() {
 				if key != "" {
-					results[key] = matches[i]
+					results[key] = matches[subIndex]
 				}
 			}
-			return results, i
+			return results, exprIndex
 		}
 	}
 	return nil, -1
 }
 
-// NewRegexGroup cache compiled regex to avoid multiple interpretation of the same regex
+// NewRegexGroup cache compiled regex to avoid multiple interpretation of the same regex.
 func NewRegexGroup(key string, definitions ...string) (result []*regexp.Regexp, err error) {
 	result = make([]*regexp.Regexp, len(definitions))
 	for i := range definitions {

--- a/reutils/multimatch.go
+++ b/reutils/multimatch.go
@@ -1,0 +1,55 @@
+package reutils
+
+import (
+	"regexp"
+	"sync"
+)
+
+// MultiMatch returns a map of matching elements from a list of regular expressions (returning the first matching element)
+func MultiMatch(s string, expressions ...*regexp.Regexp) (map[string]string, int) {
+	for i, re := range expressions {
+		if matches := re.FindStringSubmatch(s); len(matches) != 0 {
+			results := make(map[string]string, len(matches))
+			results[""] = matches[0]
+			for i, key := range re.SubexpNames() {
+				if key != "" {
+					results[key] = matches[i]
+				}
+			}
+			return results, i
+		}
+	}
+	return nil, -1
+}
+
+// NewRegexGroup cache compiled regex to avoid multiple interpretation of the same regex
+func NewRegexGroup(key string, definitions ...string) (result []*regexp.Regexp, err error) {
+	result = make([]*regexp.Regexp, len(definitions))
+	for i := range definitions {
+		regex, err := regexp.Compile(definitions[i])
+		if err != nil {
+			return nil, err
+		}
+		result[i] = regex
+	}
+
+	cachedRegex.Store(key, result)
+	return
+}
+
+// GetRegexGroup tries to retreive a regular expression group previously created by NewRegexGroup.
+func GetRegexGroup(key string) (result []*regexp.Regexp) {
+	if cached, ok := cachedRegex.Load(key); ok {
+		result = cached.([]*regexp.Regexp)
+	}
+	return
+}
+
+// DeleteRegexGroup tries to retreive a regular expression group previously created by NewRegexGroup.
+func DeleteRegexGroup(key string) (result []*regexp.Regexp) {
+	result = GetRegexGroup(key)
+	cachedRegex.Delete(key)
+	return
+}
+
+var cachedRegex sync.Map

--- a/reutils/multimatch_test.go
+++ b/reutils/multimatch_test.go
@@ -20,11 +20,13 @@ func TestMultiMatch(t *testing.T) {
 		match       int
 	}{
 		{"empty", "", nil, nil, -1},
-		{"single", "Hello", []*regexp.Regexp{
-			regexp.MustCompile(`H`),
-		}, map[string]string{
-			"": "H",
-		}, 0},
+		{
+			"single", "Hello", []*regexp.Regexp{
+				regexp.MustCompile(`H`),
+			}, map[string]string{
+				"": "H",
+			}, 0,
+		},
 		{
 			"hello", "Hello world!", []*regexp.Regexp{
 				regexp.MustCompile(`\w+`),

--- a/reutils/multimatch_test.go
+++ b/reutils/multimatch_test.go
@@ -1,0 +1,90 @@
+package reutils
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiMatch(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name        string
+		s           string
+		expressions []*regexp.Regexp
+		want        map[string]string
+		match       int
+	}{
+		{"empty", "", nil, nil, -1},
+		{"single", "Hello", []*regexp.Regexp{
+			regexp.MustCompile(`H`),
+		}, map[string]string{
+			"": "H",
+		}, 0},
+		{
+			"hello", "Hello world!", []*regexp.Regexp{
+				regexp.MustCompile(`\w+`),
+			}, map[string]string{
+				"": "Hello",
+			}, 0,
+		},
+		{
+			"hello", "Hello world!", []*regexp.Regexp{
+				regexp.MustCompile(`^\w+$`),
+				regexp.MustCompile(`^Hello (?P<who>\w+).*$`),
+			}, map[string]string{
+				"":    "Hello world!",
+				"who": "world",
+			}, 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, match := MultiMatch(tt.s, tt.expressions...)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.match, match)
+		})
+	}
+}
+
+func ExampleGetRegexGroup() {
+	// Create a group.
+	if _, err := NewRegexGroup("test", `^\w+$`, `^Hello (?P<who>\w+).*$`); err != nil {
+		fmt.Println("Invalid group definition", err)
+	}
+
+	result, match := MultiMatch("Hello world!", GetRegexGroup("test")...)
+	fmt.Printf("Matched group %d\n", match)
+	fmt.Println(result)
+	// Output:
+	// Matched group 1
+	// map[:Hello world! who:world]
+}
+
+func ExampleDeleteRegexGroup() {
+	NewRegexGroup("test", `^\w+$`, `^Hello (?P<who>\w+).*$`)
+	result := DeleteRegexGroup("test")
+	fmt.Println(result)
+	// Output:
+	// [^\w+$ ^Hello (?P<who>\w+).*$]
+}
+
+func ExampleDeleteRegexGroup_not_existing() {
+	result := DeleteRegexGroup("not existing")
+	fmt.Println(result)
+	// Output:
+	// []
+}
+
+func ExampleNewRegexGroup_with_error() {
+	// All supplied regular expressions must be valid.
+	if _, err := NewRegexGroup("test", `^\w+$`, `^Hello (?P(who)\w+).*$`); err != nil {
+		fmt.Println("Invalid group definition", err)
+	}
+	// Output:
+	// Invalid group definition error parsing regexp: invalid or unsupported Perl syntax: `(?P`
+}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,57 @@
+package multilogger
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// FormatDuration returns a string to represent the duration.
+func FormatDuration(duration time.Duration) string {
+	const day = 24 * time.Hour
+	const week = 7 * day
+	const month = 30 * day
+	const year = 365 * day
+	duration = duration.Round(time.Microsecond)
+	result := ""
+	if duration >= time.Hour {
+		duration = duration.Round(time.Second / 10)
+	}
+	if duration > year {
+		result = fmt.Sprintf("%dy", duration/year)
+		duration = duration % year
+	}
+	if duration > 45*day {
+		result = fmt.Sprintf("%s%dmo", result, duration/month)
+		duration = duration % month
+	}
+	if duration >= 2*week {
+		duration = duration.Round(time.Second)
+		result = fmt.Sprintf("%s%dw", result, duration/week)
+		duration = duration % week
+	}
+	if duration > day {
+		result = fmt.Sprintf("%s%dd", result, duration/day)
+		duration = duration % day
+	}
+	return fmt.Sprintf("%s%s", result, duration)
+}
+
+// ParseBool returns true for any value that is set and is not clearly a false.
+// It never returns an error.
+//
+// True values are: 1, t, true, yes, y, on (of any non false value)
+// False values are: 0, f, false, no, n, off
+func ParseBool(value string) bool {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if result, err := strconv.ParseBool(value); err == nil {
+		return result
+	}
+
+	switch value {
+	case "", "no", "n", "off":
+		return false
+	}
+	return true
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,39 @@
+package multilogger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseBool(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"True", true},
+		{"  True  	\n", true},
+		{"T", true},
+		{"t", true},
+		{"TrUe", true},
+		{"On", true},
+		{"Y", true},
+		{"Yes", true},
+		{"Whatever", true},
+		{"False", false},
+		{"FaLsE", false},
+		{"f", false},
+		{"off", false},
+		{"No", false},
+		{"n", false},
+		{"NO", false},
+		{"	 no  		", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseBool(tt.name); got != tt.want {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Move gotemplate/errors to multilogger/errorss
- Move regex utils function gotemplate/utils to multilogger/reutils
- Implement LogCatcher feature from terragrunt directly into miultilogger
- Add tests
- Add better management for write errors
- Move common functions to genericHook