### PR TITLE
Modifications needed to integrate with Terragrunt

### DIFF
--- a/console_hook.go
+++ b/console_hook.go
@@ -17,6 +17,16 @@ type consoleHook struct {
 	log io.Writer
 }
 
+func (hook *consoleHook) clone() logrus.Hook {
+	// Duplicate the console hook to ensure that the copy
+	// has its own attributes when the object is copied.
+	return &consoleHook{
+		genericHook: hook.genericHook,
+		out:         hook.out,
+		log:         hook.log,
+	}
+}
+
 func (hook *consoleHook) Fire(entry *logrus.Entry) (err error) {
 	return hook.fire(entry, func() error {
 		const name = "ConsoleHook"

--- a/hook.go
+++ b/hook.go
@@ -8,6 +8,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type cloneable interface {
+	clone() logrus.Hook
+}
+
 // NewHook generates a named hook wrapper that is able the handle its own logging level.
 //
 // level: Accept any kind of object, but must be resolvable into a valid logrus level name.
@@ -162,4 +166,9 @@ func (hook *Hook) SetOut(out io.Writer) *Hook {
 func (hook *Hook) SetStdout(out io.Writer) *Hook {
 	hook.inner.(consoleI).SetStdout(out)
 	return hook
+}
+
+// GetInnerHook returns the inner hook actually used by the leveled hook.
+func (hook *Hook) GetInnerHook() logrus.Hook {
+	return hook.inner
 }

--- a/logger_catcher_test.go
+++ b/logger_catcher_test.go
@@ -73,9 +73,7 @@ func TestLogger_Write(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var output, logs bytes.Buffer
-			log := getTestLogger(tt.name, "Trace")
-			log.Hook("").SetOut(&logs)
-			log.Hook("").SetStdout(&output)
+			log := getTestLogger(tt.name, "Trace").SetOut(&logs).SetStdout(&output)
 
 			for i, p := range tt.sequence {
 				i++
@@ -110,9 +108,7 @@ func TestLogCatcher_WriteWithError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			log := getTestLogger(tt.name, "trace")
-			log.Hook("").SetOut(&buggyWriter{tt.err})
-			log.Hook("").SetStdout(&buggyWriter{tt.err})
+			log := getTestLogger(tt.name, "trace").SetAllOutputs(&buggyWriter{tt.err})
 
 			gotResultCount, err := log.Write([]byte(tt.text))
 			if err == nil {

--- a/logger_console.go
+++ b/logger_console.go
@@ -1,0 +1,81 @@
+package multilogger
+
+import (
+	"io"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// DefaultConsoleFormat is the format used by NewConsoleHook if MULTILOGGER_FORMAT is not set.
+	DefaultConsoleFormat = "%module:Italic,Green,SquareBrackets,IgnoreEmpty,Space%%time% %-8level:upper,color% %message:color%"
+	consoleHookName      = "console-hook"
+)
+
+// GetDefaultConsoleHook returns the default console hook.
+func (logger *Logger) GetDefaultConsoleHook() *Hook { return logger.Hook(consoleHookName) }
+
+// GetDefaultConsoleHookLevel returns the logging level associated to the default console hook.
+func (logger *Logger) GetDefaultConsoleHookLevel() logrus.Level {
+	return logger.GetHookLevel(consoleHookName)
+}
+
+// SetDefaultConsoleHookLevel set a new log level for the default console hook.
+func (logger *Logger) SetDefaultConsoleHookLevel(level interface{}) error {
+	return logger.SetHookLevel(consoleHookName, level)
+}
+
+// GetFormatter returns the formater associated to the default console hook.
+func (logger *Logger) GetFormatter() (result logrus.Formatter) {
+	logger.onDefaultHook(func(ch *Hook) { result = ch.GetFormatter() })
+	return
+}
+
+// Formatter returns the Formatter associated to the default console hook.
+func (logger *Logger) Formatter() (result *Formatter) {
+	logger.onDefaultHook(func(ch *Hook) { result = ch.Formatter() })
+	return
+}
+
+// SetFormatter allows setting a formatter to the default console hook if there is.
+func (logger *Logger) SetFormatter(formatter logrus.Formatter) *Logger {
+	return logger.onDefaultHook(func(ch *Hook) { ch.SetFormatter(formatter) })
+}
+
+// SetFormat allows setting a format string on the default console hook if there is.
+func (logger *Logger) SetFormat(formats ...interface{}) *Logger {
+	return logger.onDefaultHook(func(ch *Hook) { ch.SetFormat(formats...) })
+}
+
+// SetColor allows setting color mode on the default console hook if there is.
+func (logger *Logger) SetColor(color bool) *Logger {
+	return logger.onDefaultHook(func(ch *Hook) { ch.SetColor(color) })
+}
+
+// SetOut allows configuring the logging stream on the default console hook if there is.
+func (logger *Logger) SetOut(out io.Writer) *Logger {
+	return logger.onDefaultHook(func(ch *Hook) { ch.SetOut(out) })
+}
+
+// SetStdout allows configuring the output stream on the default console hook if there is.
+func (logger *Logger) SetStdout(out io.Writer) *Logger {
+	return logger.onDefaultHook(func(ch *Hook) { ch.SetStdout(out) })
+}
+
+// SetAllOutputs allows configuring the output and the logging stream on the default console hook if there is.
+func (logger *Logger) SetAllOutputs(out io.Writer) *Logger {
+	return logger.onDefaultHook(func(ch *Hook) { ch.SetOut(out).SetStdout(out) })
+}
+
+// GetDefaultInnerHook returns the inner hook actually used by the default console hook.
+func (logger *Logger) GetDefaultInnerHook() (result logrus.Hook) {
+	logger.onDefaultHook(func(ch *Hook) { result = ch.GetInnerHook() })
+	return
+}
+
+func (logger *Logger) onDefaultHook(action func(*Hook)) *Logger {
+	if ch := logger.GetDefaultConsoleHook(); ch != nil {
+		action(ch)
+	}
+	return logger
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -62,10 +62,12 @@ func ExampleLogger_Copy() {
 	log.Info("Log from original")
 	log.Copy("copy").Trace("Log from copy")
 	log.Copy("").Debug("I have no module")
+	log.Copy().Debug("I have the same module as the original")
 	// Output:
 	// [original] 2018/06/24 12:34:56.789 INFO     Log from original
 	// [copy] 2018/06/24 12:34:56.789 TRACE    Log from copy
 	// 2018/06/24 12:34:56.789 DEBUG    I have no module
+	// [original] 2018/06/24 12:34:56.789 DEBUG    I have the same module as the original
 }
 
 func ExampleLogger_Child() {
@@ -109,7 +111,7 @@ func ExampleLogger_WithField() {
 	log := getTestLogger("field", "Trace")
 
 	// We set the format of the log to include fields
-	log.Hook("").SetFormat("%module:square% %time% %level:upper% %message% %fields%.")
+	log.SetFormat("%module:square% %time% %level:upper% %message% %fields%.")
 
 	// We create a new logger with additional context
 	log2 := log.WithField("hello", "world!").WithField("pi", math.Pi)
@@ -124,7 +126,7 @@ func ExampleLogger_WithFields() {
 	log := getTestLogger("field", "Trace")
 
 	// We set the format of the log to include fields
-	log.Hook("").SetFormat("%module:square% %time% %level:upper% %message% %fields%.")
+	log.SetFormat("%module:square% %time% %level:upper% %message% %fields%.")
 
 	// We create a new logger with additional context
 	log2 := log.WithFields(logrus.Fields{


### PR DESCRIPTION
- Add a log catcher copy function to help creating one log catcher for stderr and one for stdout
- Copy should copy everything (even the internal logrus logger), otherwise, hooks are shared and it is impossible to create log catchers for different writers with the same logger
- GetHookLevel has one unused parameter