### PR TITLE
Add option to log to a directory instead of a single file

### DIFF
--- a/console_hook.go
+++ b/console_hook.go
@@ -21,9 +21,12 @@ func (hook *consoleHook) clone() logrus.Hook {
 	// Duplicate the console hook to ensure that the copy
 	// has its own attributes when the object is copied.
 	return &consoleHook{
-		genericHook: hook.genericHook,
-		out:         hook.out,
-		log:         hook.log,
+		genericHook: &genericHook{
+			formatter: hook.formatter,
+			logger:    hook.logger,
+		},
+		out: hook.out,
+		log: hook.log,
 	}
 }
 

--- a/console_hook.go
+++ b/console_hook.go
@@ -21,12 +21,9 @@ func (hook *consoleHook) clone() logrus.Hook {
 	// Duplicate the console hook to ensure that the copy
 	// has its own attributes when the object is copied.
 	return &consoleHook{
-		genericHook: &genericHook{
-			formatter: hook.formatter,
-			logger:    hook.logger,
-		},
-		out: hook.out,
-		log: hook.log,
+		genericHook: hook.genericHook.clone(),
+		out:         hook.out,
+		log:         hook.log,
 	}
 }
 

--- a/file_hook.go
+++ b/file_hook.go
@@ -23,14 +23,11 @@ func (hook *fileHook) clone() logrus.Hook {
 	// Duplicate the file hook to ensure that the copy
 	// has its own attributes when the object is copied.
 	return &fileHook{
-		genericHook: &genericHook{
-			formatter: hook.formatter,
-			logger:    hook.logger,
-		},
-		filename:  hook.filename,
-		isDir:     hook.isDir,
-		file:      hook.file,
-		addHeader: hook.addHeader,
+		genericHook: hook.genericHook.clone(),
+		filename:    hook.filename,
+		isDir:       hook.isDir,
+		file:        hook.file,
+		addHeader:   hook.addHeader,
 	}
 }
 

--- a/file_hook.go
+++ b/file_hook.go
@@ -3,6 +3,9 @@ package multilogger
 import (
 	"fmt"
 	"os"
+	"path"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -11,8 +14,24 @@ import (
 type fileHook struct {
 	*genericHook
 	filename  string
+	isDir     bool
 	file      *os.File
 	addHeader bool
+}
+
+func (hook *fileHook) clone() logrus.Hook {
+	// Duplicate the file hook to ensure that the copy
+	// has its own attributes when the object is copied.
+	return &fileHook{
+		genericHook: &genericHook{
+			formatter: hook.formatter,
+			logger:    hook.logger,
+		},
+		filename:  hook.filename,
+		isDir:     hook.isDir,
+		file:      hook.file,
+		addHeader: hook.addHeader,
+	}
 }
 
 func (hook *fileHook) Fire(entry *logrus.Entry) (err error) {
@@ -27,12 +46,22 @@ func (hook *fileHook) Fire(entry *logrus.Entry) (err error) {
 
 		fileMutex.Lock()
 		defer fileMutex.Unlock()
+		targetFile := hook.filename
+		if hook.isDir {
+			targetFile = path.Join(hook.filename, strings.Replace(hook.logger.GetModule(), ":", ".", -1)) + ".log"
+			if targetFile, err = filepath.Abs(targetFile); err != nil {
+				return err
+			}
+			if hook.file != nil && hook.file.Name() != targetFile {
+				hook.file = nil
+			}
+		}
 		if hook.file == nil {
 			logFileExists := false
-			if _, err := os.Stat(hook.filename); err == nil {
+			if _, err := os.Stat(targetFile); err == nil {
 				logFileExists = true
 			}
-			if hook.file, err = os.OpenFile(hook.filename, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0666); err != nil {
+			if hook.file, err = os.OpenFile(targetFile, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0666); err != nil {
 				return fmt.Errorf("%s: %w", name, err)
 			}
 			if hook.addHeader {

--- a/generic_hook.go
+++ b/generic_hook.go
@@ -23,6 +23,10 @@ type genericHook struct {
 	logger    *Logger
 }
 
+func (hook genericHook) clone() *genericHook {
+	return &hook
+}
+
 func (hook *genericHook) formatEntry(name string, entry *logrus.Entry) (string, error) {
 	if hook.formatter == nil {
 		hook.formatter = NewFormatter(true, os.Getenv(FormatFileEnvVar), os.Getenv(FormatEnvVar), DefaultFileFormat)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/fatih/color v1.7.0
-	github.com/go-errors/errors v1.0.1
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
-github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/hook.go
+++ b/hook.go
@@ -40,12 +40,13 @@ func NewConsoleHook(name string, level interface{}, format ...interface{}) *Hook
 // NewFileHook creates a new hook to log information into a file.
 //
 // level: Accept any kind of object, but must be resolvable into a valid logrus level name.
-func NewFileHook(filename string, level interface{}, format ...interface{}) *Hook {
+func NewFileHook(filename string, isDir bool, level interface{}, format ...interface{}) *Hook {
 	if format == nil {
 		format = append(format, NewFormatter(false, os.Getenv(FormatFileEnvVar), os.Getenv(FormatEnvVar), DefaultFileFormat))
 	}
 	return NewHook(filename, level, &fileHook{
 		genericHook: &genericHook{formatter: getFormatter(false, format...)},
+		isDir:       isDir,
 		filename:    filename,
 		addHeader:   true,
 	})

--- a/logger.go
+++ b/logger.go
@@ -235,8 +235,8 @@ func (logger *Logger) AddConsole(name string, level interface{}, format ...inter
 }
 
 // AddFile adds a file hook to the current logger.
-func (logger *Logger) AddFile(filename string, level interface{}, format ...interface{}) *Logger {
-	return logger.AddHooks(NewFileHook(filename, level, format...))
+func (logger *Logger) AddFile(filename string, isDir bool, level interface{}, format ...interface{}) *Logger {
+	return logger.AddHooks(NewFileHook(filename, isDir, level, format...))
 }
 
 // RemoveHook deletes a hook from the hook collection.


### PR DESCRIPTION
This creates log files based on the current module name
In case of a child logger, it creates a new file but the old one is still active