### PR TITLE
Fix concurrency issues

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,4 +16,4 @@ jobs:
 
       - name: Run Tests
         run: |
-          go test ./... -v
+          go test ./... -v -count 5

--- a/formatter.go
+++ b/formatter.go
@@ -50,6 +50,7 @@ type Formatter struct {
 	replacer       *replacer
 	color          bool
 	initOnce       sync.Once
+	replacerLock   sync.Mutex
 	baseTime, last time.Time
 }
 

--- a/formatter_helper.go
+++ b/formatter_helper.go
@@ -15,11 +15,13 @@ import (
 )
 
 func (f *Formatter) doFormat(entry *logrus.Entry) (string, error) {
+	f.replacerLock.Lock()
 	if f.replacer == nil {
 		if err := f.presetFormatString(); err != nil {
 			return "", err
 		}
 	}
+	f.replacerLock.Unlock()
 
 	output := f.replacer.format + "\n"
 

--- a/formatter_helper.go
+++ b/formatter_helper.go
@@ -21,7 +21,7 @@ func (f *Formatter) doFormat(entry *logrus.Entry) (string, error) {
 			return "", err
 		}
 	}
-	f.replacerLock.Unlock()
+	defer f.replacerLock.Unlock()
 
 	output := f.replacer.format + "\n"
 

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -1,0 +1,40 @@
+package multilogger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatConcurrency(t *testing.T) {
+	t.Parallel()
+
+	logger := New("my_module")
+	formatter := logger.Formatter()
+
+	numberOfThreads := 1000
+	resultChannel := make(chan string, numberOfThreads)
+	for i := 0; i < numberOfThreads; i++ {
+		go func() {
+			entry := &logrus.Entry{
+				Message: color.BlueString("test"),
+				Level:   logrus.InfoLevel,
+				Time:    time.Date(2019, 12, 1, 10, 10, 11, 0, time.UTC),
+				Logger:  logger.Logger,
+				Data:    map[string]interface{}{moduleFieldName: "my_module"},
+			}
+			result, err := formatter.Format(entry)
+			assert.Nil(t, err)
+			resultChannel <- string(result)
+
+		}()
+	}
+
+	for i := 0; i < numberOfThreads; i++ {
+		assert.Equal(t, "[my_module] 2019/12/01 10:10:11.000 INFO     test\n", <-resultChannel)
+	}
+
+}


### PR DESCRIPTION
* Formatter's replacer init wasn't thread safe
* Formatter's replacer cached Sprint function was getting concurrent map write panics
* Added test that runs the code in a highly parallel way. The whole test suite is ran 5 times in parallel in Github Actions now as well