### PR TITLE
Better delays display options

### DIFF
--- a/formatter_replacer.go
+++ b/formatter_replacer.go
@@ -87,7 +87,11 @@ func (r *fieldReplacer) replace(entry *logrus.Entry, used map[string]uint) (stri
 			field = fmt.Sprint(entry.Level)
 		}
 	case tokenTime:
-		field = entry.Time.Format(r.TimestampFormat)
+		if globalZone != nil {
+			field = entry.Time.In(globalZone).Format(r.TimestampFormat)
+		} else {
+			field = entry.Time.Format(r.TimestampFormat)
+		}
 	case tokenDelta:
 		field = computeduration(r.last)
 	case tokenDelay:

--- a/utils.go
+++ b/utils.go
@@ -7,35 +7,136 @@ import (
 	"time"
 )
 
-// FormatDuration returns a string to represent the duration.
-func FormatDuration(duration time.Duration) string {
-	const day = 24 * time.Hour
-	const week = 7 * day
-	const month = 30 * day
-	const year = 365 * day
-	duration = duration.Round(time.Microsecond)
-	result := ""
-	if duration >= time.Hour {
-		duration = duration.Round(time.Second / 10)
+const (
+	day   = 24 * time.Hour
+	week  = 7 * day
+	month = 30 * day
+	year  = 12 * month
+)
+
+var units = []struct {
+	delay     time.Duration
+	divider   time.Duration
+	unitShort string
+	unitLong  string
+}{
+	{year, year, "y", "year"},
+	{45 * day, month, "mo", "month"},
+	{10 * day, week, "w", "week"},
+	{day, day, "d", "day"},
+	{time.Hour, time.Hour, "h", "hour"},
+	{time.Minute, time.Minute, "m", "minute"},
+	{time.Second, time.Second, "s", "second"},
+	{time.Millisecond, time.Millisecond, "ms", "millisecond"},
+	{time.Microsecond, time.Microsecond, "µs", "microsecond"},
+	{time.Nanosecond, time.Nanosecond, "ns", "nanosecond"},
+}
+
+// FormatDurationNative returns a string to represent the duration using the native golang duration format.
+func FormatDurationNative(duration time.Duration) string {
+	return fmt.Sprintf("%v", duration)
+}
+
+// FormatDurationNativeLong returns a string to represent the duration using the native golang duration format using long units.
+func FormatDurationNativeLong(duration time.Duration) string {
+	return formatDuration(duration, time.Minute, day, true)
+}
+
+// FormatDurationPrecise returns a string to represent the duration with precise unit for each segment 1d2h3m4s5ms6µs.
+func FormatDurationPrecise(duration time.Duration) string {
+	return formatDuration(duration, 0, 0, false)
+}
+
+// FormatDurationPreciseLong returns a string to represent the duration with precise unit for each segment using long units.
+func FormatDurationPreciseLong(duration time.Duration) string {
+	return formatDuration(duration, 0, 0, true)
+}
+
+// FormatDurationClassic returns a string to represent the duration using floating representation for values bellow 1 minutes.
+func FormatDurationClassic(duration time.Duration) string {
+	return formatDuration(duration, time.Minute, 0, false)
+}
+
+// FormatDurationClassicLong returns a string to represent the duration using floating representation for values bellow 1 minutes and display long units.
+func FormatDurationClassicLong(duration time.Duration) string {
+	return formatDuration(duration, time.Minute, 0, true)
+}
+
+// FormatDurationRounded returns a string to represent the duration with all units and reduction of the precision for large value.
+func FormatDurationRounded(duration time.Duration) string {
+	return FormatDurationPrecise(roundedDuration(duration))
+}
+
+// FormatDurationRoundedLong returns a string to represent the duration with all units and reduction of the precision for large value and display long units.
+func FormatDurationRoundedLong(duration time.Duration) string {
+	return FormatDurationPreciseLong(roundedDuration(duration))
+}
+
+// FormatDurationRoundedNative returns a string to represent the duration with reduction of the precision for large value.
+func FormatDurationRoundedNative(duration time.Duration) string {
+	return FormatDurationNative(roundedDuration(duration))
+}
+
+// FormatDurationRoundedNativeLong returns a string to represent the duration with reduction of the precision for large value and display long units.
+func FormatDurationRoundedNativeLong(duration time.Duration) string {
+	return FormatDurationNative(roundedDuration(duration))
+}
+
+func formatDuration(duration time.Duration, minUnit, maxUnit time.Duration, longUnit bool) (result string) {
+	for _, u := range units {
+		if u.delay >= maxUnit && maxUnit != 0 {
+			continue
+		}
+		if duration >= u.delay {
+			var value float64
+			if duration > minUnit {
+				div := duration / u.divider
+				value = float64(div)
+				duration -= div * u.divider
+			} else {
+				value = float64(duration) / float64(u.divider)
+				duration = 0
+			}
+			if longUnit {
+				if result != "" {
+					result += " "
+				}
+				unit := u.unitLong
+				if value >= 2 {
+					unit += "s"
+				}
+				result = fmt.Sprintf("%s%v %s", result, float64(value), unit)
+			} else {
+				result = fmt.Sprintf("%s%v%s", result, float64(value), u.unitShort)
+			}
+		}
 	}
-	if duration > year {
-		result = fmt.Sprintf("%dy", duration/year)
-		duration = duration % year
+	if result == "" {
+		if longUnit {
+			result = "0 second"
+		} else {
+			result = "0s"
+		}
 	}
-	if duration > 45*day {
-		result = fmt.Sprintf("%s%dmo", result, duration/month)
-		duration = duration % month
+	return
+}
+
+func roundedDuration(duration time.Duration) time.Duration {
+	switch {
+	case duration >= month:
+		return duration.Round(day)
+	case duration >= time.Hour:
+		return duration.Round(time.Minute)
+	case duration >= time.Minute:
+		return duration.Round(time.Second)
+	case duration >= time.Second:
+		return duration.Round(10 * time.Millisecond)
+	case duration >= time.Millisecond:
+		return duration.Round(time.Millisecond)
+	case duration >= time.Microsecond:
+		return duration.Round(time.Microsecond)
 	}
-	if duration >= 2*week {
-		duration = duration.Round(time.Second)
-		result = fmt.Sprintf("%s%dw", result, duration/week)
-		duration = duration % week
-	}
-	if duration > day {
-		result = fmt.Sprintf("%s%dd", result, duration/day)
-		duration = duration % day
-	}
-	return fmt.Sprintf("%s%s", result, duration)
+	return duration
 }
 
 // ParseBool returns true for any value that is set and is not clearly a false.

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,7 +1,11 @@
 package multilogger
 
 import (
+	"fmt"
+	"os"
 	"testing"
+	"text/tabwriter"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -36,4 +40,86 @@ func TestParseBool(t *testing.T) {
 			}
 		})
 	}
+}
+
+func ExampleFormatDurationPrecise() {
+	durations := []time.Duration{
+		0,
+		time.Nanosecond,
+		time.Microsecond,
+		time.Millisecond,
+		time.Second,
+		time.Minute,
+		time.Hour,
+		day,
+		week,
+		month,
+		year,
+		9*year + 8*month + 7*day + 6*time.Hour + 5*time.Minute + 4*time.Second + 3*time.Millisecond + 2*time.Microsecond + 1*time.Nanosecond,
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 20, 0, 1, ' ', tabwriter.TabIndent)
+
+	fmt.Fprintln(w, "Native\tClassic\tPrecise\tRounded\tNative long\tRounded long\t")
+	fmt.Fprintln(w, "------\t-------\t-------\t-------\t-----------\t------------\t")
+
+	print := func(duration time.Duration) {
+		fmt.Fprintf(w, "%v\t", duration)
+		fmt.Fprintf(w, "%s\t", FormatDurationClassic(duration))
+		fmt.Fprintf(w, "%s\t", FormatDurationPrecise(duration))
+		fmt.Fprintf(w, "%s\t", FormatDurationRounded(duration))
+		fmt.Fprintf(w, "%s\t", FormatDurationNativeLong(duration))
+		fmt.Fprintf(w, "%s\t", FormatDurationRoundedLong(duration))
+		fmt.Fprintln(w, "|")
+	}
+
+	var total time.Duration
+	for _, duration := range durations {
+		total += duration
+		print(duration)
+		if duration != 0 {
+			print(10 * duration)
+			if total != duration {
+				print(total)
+			}
+		}
+	}
+	w.Flush()
+
+	// // Output:
+	// Native                 Classic                       Precise                          Rounded             Native long                                 Rounded long
+	// ------                 -------                       -------                          -------             -----------                                 ------------
+	// 0s                     0s                            0s                               0s                  0 second                                    0 second                         |
+	// 1ns                    1ns                           1ns                              1ns                 1 nanosecond                                1 nanosecond                     |
+	// 10ns                   10ns                          10ns                             10ns                10 nanoseconds                              10 nanoseconds                   |
+	// 1µs                    1µs                           1µs                              1µs                 1 microsecond                               1 microsecond                    |
+	// 10µs                   10µs                          10µs                             10µs                10 microseconds                             10 microseconds                  |
+	// 1.001µs                1.001µs                       1µs1ns                           1µs                 1.001 microsecond                           1 microsecond                    |
+	// 1ms                    1ms                           1ms                              1ms                 1 millisecond                               1 millisecond                    |
+	// 10ms                   10ms                          10ms                             10ms                10 milliseconds                             10 milliseconds                  |
+	// 1.001001ms             1.001001ms                    1ms1µs1ns                        1ms                 1.001001 millisecond                        1 millisecond                    |
+	// 1s                     1s                            1s                               1s                  1 second                                    1 second                         |
+	// 10s                    10s                           10s                              10s                 10 seconds                                  10 seconds                       |
+	// 1.001001001s           1.001001001s                  1s1ms1µs1ns                      1s                  1.001001001 second                          1 second                         |
+	// 1m0s                   1m                            1m                               1m                  1 minute                                    1 minute                         |
+	// 10m0s                  10m                           10m                              10m                 10 minutes                                  10 minutes                       |
+	// 1m1.001001001s         1m1.001001001s                1m1s1ms1µs1ns                    1m1s                1 minute 1.001001001 second                 1 minute 1 second                |
+	// 1h0m0s                 1h                            1h                               1h                  1 hour                                      1 hour                           |
+	// 10h0m0s                10h                           10h                              10h                 10 hours                                    10 hours                         |
+	// 1h1m1.001001001s       1h1m1.001001001s              1h1m1s1ms1µs1ns                  1h1m                1 hour 1 minute 1.001001001 second          1 hour 1 minute                  |
+	// 24h0m0s                1d                            1d                               1d                  24 hours                                    1 day                            |
+	// 240h0m0s               1w3d                          1w3d                             1w3d                240 hours                                   1 week 3 days                    |
+	// 25h1m1.001001001s      1d1h1m1.001001001s            1d1h1m1s1ms1µs1ns                1d1h1m              25 hours 1 minute 1.001001001 second        1 day 1 hour 1 minute            |
+	// 168h0m0s               7d                            7d                               7d                  168 hours                                   7 days                           |
+	// 1680h0m0s              2mo1w3d                       2mo1w3d                          2mo1w3d             1680 hours                                  2 months 1 week 3 days           |
+	// 193h1m1.001001001s     8d1h1m1.001001001s            8d1h1m1s1ms1µs1ns                8d1h1m              193 hours 1 minute 1.001001001 second       8 days 1 hour 1 minute           |
+	// 720h0m0s               4w2d                          4w2d                             4w2d                720 hours                                   4 weeks 2 days                   |
+	// 7200h0m0s              10mo                          10mo                             10mo                7200 hours                                  10 months                        |
+	// 913h1m1.001001001s     5w3d1h1m1.001001001s          5w3d1h1m1s1ms1µs1ns              5w3d                913 hours 1 minute 1.001001001 second       5 weeks 3 days                   |
+	// 8640h0m0s              1y                            1y                               1y                  8640 hours                                  1 year                           |
+	// 86400h0m0s             10y                           10y                              10y                 86400 hours                                 10 years                         |
+	// 9553h1m1.001001001s    1y5w3d1h1m1.001001001s        1y5w3d1h1m1s1ms1µs1ns            1y5w3d              9553 hours 1 minute 1.001001001 second      1 year 5 weeks 3 days            |
+	// 83694h5m4.003002001s   9y8mo7d6h5m4.003002001s       9y8mo7d6h5m4s3ms2µs1ns           9y8mo7d             83694 hours 5 minutes 4.003002001 seconds   9 years 8 months 7 days          |
+	// 836940h50m40.03002001s 96y10mo1w5d12h50m40.03002001s 96y10mo1w5d12h50m40s30ms20µs10ns 96y10mo1w6d         836940 hours 50 minutes 40.03002001 seconds 96 years 10 months 1 week 6 days |
+	// 93247h6m5.004003002s   10y9mo2w1d7h6m5.004003002s    10y9mo2w1d7h6m5s4ms3µs2ns        10y9mo2w1d          93247 hours 6 minutes 5.004003002 seconds   10 years 9 months 2 weeks 1 day  |
 }


### PR DESCRIPTION
- Fix time zone problem when a subprocess is not running in  the same time zone as the main process
- Add more option to display durations without being overwhelmed by too much precision on large duration.
