### PR TITLE
fix typo; fix integer overflow for 32bit systems

### DIFF
--- a/level.go
+++ b/level.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// DisabledLevel can be set when one of the logging hooks should be disabled.
-	DisabledLevel     logrus.Level = math.MaxUint32
+	DisabledLevel     logrus.Level = math.MaxInt32
 	outputLevel                    = DisabledLevel - 1
 	disabledLevelName string       = "disabled"
 )
@@ -32,7 +32,7 @@ func AcceptedLevelsString() string {
 }
 
 // ParseLogLevel converts a string or number into a logging level.
-// It panics if the supplied valid cannot be converted into a valid logrus Level.
+// It panics if the supplied value cannot be converted into a valid logrus Level.
 func ParseLogLevel(level interface{}) logrus.Level {
 	return errors.Must(TryParseLogLevel(level)).(logrus.Level)
 }


### PR DESCRIPTION
Got this error while building your `gotemplate` project for `linux/arm/v6` and `linux/arm/v7`. This looks like an obvious miss of support of 32bit -based systems. I bet you skip such systems because of various places where it might not work, but if this PR doesn't hurt then it might be  a small stop toward it.
I'm not familiar with where you use this library, so cannot guarantee it doesn't break something :)